### PR TITLE
Improves tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 !.yarn/versions
 
 # testing
-/coverage
+app/coverage
 
 # next.js
 /.next/

--- a/app/__tests__/Table.test.js
+++ b/app/__tests__/Table.test.js
@@ -1,7 +1,11 @@
+import preloadAll from "jest-next-dynamic";
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import Table from "../components/Table";
 
-jest.mock("../lib/fetchData"); // Mock the fetchData function
+beforeAll(async () => {
+  await preloadAll();
+});
 
 describe("Table Component", () => {
   // Test if the table renders columns and data
@@ -17,7 +21,26 @@ describe("Table Component", () => {
     ).toBeInTheDocument(); // Data cell
   });
 
-  // TODO: Test if data is fetched and the correct number of rows are displayed
+  it("renders links in cells", () => {
+    // Test if the table correctly creates links when desired.
+    const columnsConfig = [
+      {
+        title: "Package ID",
+        data: "identifier",
+        type: "link",
+        linkPrefix: "/objects/",
+        identifierKey: "identifier",
+      },
+    ];
+    const data = [{ identifier: "8bf992c0-1547-403a-93d4-ac531e7ed080" }];
 
-  //TODO: Test if an error message is displayed if data fetching fails
+    render(<Table columnsConfig={columnsConfig} data={data} />);
+
+    expect(
+      screen.getByText("8bf992c0-1547-403a-93d4-ac531e7ed080"),
+    ).toHaveAttribute("href");
+    expect(screen.getByText("8bf992c0-1547-403a-93d4-ac531e7ed080").href).toBe(
+      "http://localhost/objects/8bf992c0-1547-403a-93d4-ac531e7ed080",
+    );
+  });
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test": "jest --coverage",
     "prepare": "husky"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "babel-plugin-dynamic-import-node": "^2.3.3",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
     "eslint-config-prettier": "^10.1.1",
@@ -28,6 +29,7 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-next-dynamic": "^1.0.2",
     "lint-staged": "^15.5.0",
     "prettier": "3.5.3",
     "ts-node": "^10.9.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
-    "babel-plugin-dynamic-import-node": "^2.3.3",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
     "eslint-config-prettier": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,6 +1482,13 @@ babel-jest@^29.7.0:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
+babel-plugin-dynamic-import-node@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
+  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
+  dependencies:
+    object.assign "^4.1.0"
+
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
@@ -3395,6 +3402,11 @@ jest-mock@^29.7.0:
     "@types/node" "*"
     jest-util "^29.7.0"
 
+jest-next-dynamic@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jest-next-dynamic/-/jest-next-dynamic-1.0.2.tgz#25888dd4f5b425132b0ea8650657da2064f86023"
+  integrity sha512-4vKTkNji+fytsAeGyZF0pSRwtTEaa3Z4pnPDDNAe0aQXz2yenUU/L03vB9vt/6gdcl8vmBVa9m9smZ9FZCerDw==
+
 jest-pnp-resolver@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz#930b1546164d4ad5937d5540e711d4d38d4cad2e"
@@ -3980,7 +3992,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.4, object.assign@^4.1.7:
+object.assign@^4.1.0, object.assign@^4.1.4, object.assign@^4.1.7:
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.7.tgz#8c14ca1a424c6a561b0bb2a22f66f5049a945d3d"
   integrity sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,13 +1482,6 @@ babel-jest@^29.7.0:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-plugin-dynamic-import-node@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
-  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  dependencies:
-    object.assign "^4.1.0"
-
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
@@ -3992,7 +3985,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0, object.assign@^4.1.4, object.assign@^4.1.7:
+object.assign@^4.1.4, object.assign@^4.1.7:
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.7.tgz#8c14ca1a424c6a561b0bb2a22f66f5049a945d3d"
   integrity sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==


### PR DESCRIPTION
Contributes to issue #12 

Makes a couple of tweaks to testing:
- Runs jest with `--coverage` flag to produce coverage report, and gitignores the resulting files.
- Ensures that dynamic components can be tested by adding the `jest-next-dynamic` package and using `preloadAll` in the tests.
- Adds additional tests to the Table component. This gets our coverage up to 100%

I noticed there were some additional testing behaviors identified in `Table.test.js` however those behaviors are in the page, not the component, so those tests belong in a different place IMO.