### PR TITLE
Use server side fetching

### DIFF
--- a/app/__tests__/PackageDetailPage.test.js
+++ b/app/__tests__/PackageDetailPage.test.js
@@ -3,8 +3,8 @@ import "@testing-library/jest-dom";
 import PackageDetail from "../packages/[identifier]/page";
 import { fetchData } from "../lib/fetchData";
 
-// Mock the fetchData function
-jest.mock("../lib/fetchData");
+jest.mock("../lib/fetchData"); // Mock the fetchData function
+jest.mock("../components/Table"); // Mock the Table component, tested elsewhere
 
 const mockPackageData = {
   identifier: "f78742e5-6af9-4756-a94a-6cd297406d51",
@@ -55,13 +55,6 @@ describe("Package Detail Page", () => {
     // Check if package identifier and origin are rendered
     expect(screen.getByText(mockPackageData.identifier)).toBeInTheDocument();
     expect(screen.getByText(mockPackageData.origin)).toBeInTheDocument();
-
-    // Wait for datatables to load content and check if the content is rendered
-    await waitFor(() => {
-      expect(screen.getByText(mockEventsData[0].service)).toBeInTheDocument();
-      expect(screen.getByText(mockEventsData[0].outcome)).toBeInTheDocument();
-      expect(screen.getByText(mockEventsData[0].message)).toBeInTheDocument();
-    });
 
     // Check if external identifiers are rendered (or "None" if undefined)
     expect(

--- a/app/__tests__/PackageDetailPage.test.js
+++ b/app/__tests__/PackageDetailPage.test.js
@@ -45,7 +45,9 @@ describe("Package Detail Page", () => {
     expect(screen.getByText(mockPackageData.origin)).toBeInTheDocument();
 
     // Check if outcome is rendered
-    expect(screen.getByText(`STATUS: ${mockPackageData.last_outcome}`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`STATUS: ${mockPackageData.last_outcome}`),
+    ).toBeInTheDocument();
 
     // Check if external identifiers are rendered (or "None" if undefined)
     expect(

--- a/app/__tests__/PackageDetailPage.test.js
+++ b/app/__tests__/PackageDetailPage.test.js
@@ -10,6 +10,7 @@ const mockPackageData = {
   identifier: "f78742e5-6af9-4756-a94a-6cd297406d51",
   title: "Test Package",
   origin: "aurora",
+  last_outcome: "SUCCESS",
   identifiers: {
     aurora_package:
       "https://aurora.dev.rockarch.org/api/transfers/1631/?format=json",
@@ -20,26 +21,13 @@ const mockPackageData = {
   },
 };
 
-const mockEventsData = [
-  {
-    identifier: "f78742e5-6af9-4756-a94a-6cd297406d55",
-    service: "test_service",
-    outcome: "SUCCESS",
-    last_modified: "2025-02-26T15:12:29.176000Z",
-    message: "Package discovered.",
-  },
-];
-
 describe("Package Detail Page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("renders package detail page", async () => {
-    fetchData.mockImplementation((url) => {
-      if (url.includes("/events")) {
-        return Promise.resolve(mockEventsData);
-      }
+    fetchData.mockImplementation(() => {
       return Promise.resolve(mockPackageData);
     });
 
@@ -55,6 +43,9 @@ describe("Package Detail Page", () => {
     // Check if package identifier and origin are rendered
     expect(screen.getByText(mockPackageData.identifier)).toBeInTheDocument();
     expect(screen.getByText(mockPackageData.origin)).toBeInTheDocument();
+
+    // Check if outcome is rendered
+    expect(screen.getByText(`STATUS: ${mockPackageData.last_outcome}`)).toBeInTheDocument();
 
     // Check if external identifiers are rendered (or "None" if undefined)
     expect(

--- a/app/__tests__/Table.test.js
+++ b/app/__tests__/Table.test.js
@@ -3,35 +3,39 @@ import "@testing-library/jest-dom";
 
 describe("Construct columns function", () => {
   it("correctly creates basic cell", () => {
-    const columnsConfig = [{ title: "Package ID", data: "identifier" }]
-    const output = constructColumns(columnsConfig)
-    expect(output).toStrictEqual(columnsConfig)
+    const columnsConfig = [{ title: "Package ID", data: "identifier" }];
+    const output = constructColumns(columnsConfig);
+    expect(output).toStrictEqual(columnsConfig);
   });
 
   it("correctly creates link cell", () => {
-    const columnsConfig = [{
-      title: "Title",
-      data: "title",
-      type: "link",
-      linkPrefix: "/packages/",
-      identifierKey: "identifier",
-    }]
+    const columnsConfig = [
+      {
+        title: "Title",
+        data: "title",
+        type: "link",
+        linkPrefix: "/packages/",
+        identifierKey: "identifier",
+      },
+    ];
     const output = constructColumns(columnsConfig);
-    expect(output[0]).toEqual(
-      expect.objectContaining(columnsConfig[0])
-    );
-    expect(output[0].render).toStrictEqual(expect.any(Function))
+    expect(output[0]).toEqual(expect.objectContaining(columnsConfig[0]));
+    expect(output[0].render).toStrictEqual(expect.any(Function));
   });
 });
 
 describe("Construct URL function", () => {
   it("correctly creates search params", () => {
-    const output = constructUrl('packages')
-    expect(output).toBe(`${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?format=datatables`)
+    const output = constructUrl("packages");
+    expect(output).toBe(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?format=datatables`,
+    );
   });
 
   it("correctly adds to exisitng search params", () => {
-    const output = constructUrl('packages?outcome=SUCCESS')
-    expect(output).toBe(`${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?outcome=SUCCESS&format=datatables`)
+    const output = constructUrl("packages?outcome=SUCCESS");
+    expect(output).toBe(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?outcome=SUCCESS&format=datatables`,
+    );
   });
 });

--- a/app/__tests__/Table.test.js
+++ b/app/__tests__/Table.test.js
@@ -32,7 +32,7 @@ describe("Construct URL function", () => {
     );
   });
 
-  it("correctly adds to exisitng search params", () => {
+  it("correctly adds to existing search params", () => {
     const output = constructUrl("packages?outcome=SUCCESS");
     expect(output).toBe(
       `${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?outcome=SUCCESS&format=datatables`,

--- a/app/__tests__/Table.test.js
+++ b/app/__tests__/Table.test.js
@@ -1,46 +1,37 @@
-import preloadAll from "jest-next-dynamic";
-import { render, screen } from "@testing-library/react";
+import { constructColumns, constructUrl } from "@/components/Table";
 import "@testing-library/jest-dom";
-import Table from "../components/Table";
 
-beforeAll(async () => {
-  await preloadAll();
-});
-
-describe("Table Component", () => {
-  // Test if the table renders columns and data
-  it("renders the table", () => {
-    const columnsConfig = [{ title: "Package ID", data: "identifier" }];
-    const data = [{ identifier: "8bf992c0-1547-403a-93d4-ac531e7ed080" }];
-
-    render(<Table columnsConfig={columnsConfig} data={data} />);
-
-    expect(screen.getByText("Package ID")).toBeInTheDocument();
-    expect(
-      screen.getByText("8bf992c0-1547-403a-93d4-ac531e7ed080"),
-    ).toBeInTheDocument(); // Data cell
+describe("Construct columns function", () => {
+  it("correctly creates basic cell", () => {
+    const columnsConfig = [{ title: "Package ID", data: "identifier" }]
+    const output = constructColumns(columnsConfig)
+    expect(output).toStrictEqual(columnsConfig)
   });
 
-  it("renders links in cells", () => {
-    // Test if the table correctly creates links when desired.
-    const columnsConfig = [
-      {
-        title: "Package ID",
-        data: "identifier",
-        type: "link",
-        linkPrefix: "/objects/",
-        identifierKey: "identifier",
-      },
-    ];
-    const data = [{ identifier: "8bf992c0-1547-403a-93d4-ac531e7ed080" }];
-
-    render(<Table columnsConfig={columnsConfig} data={data} />);
-
-    expect(
-      screen.getByText("8bf992c0-1547-403a-93d4-ac531e7ed080"),
-    ).toHaveAttribute("href");
-    expect(screen.getByText("8bf992c0-1547-403a-93d4-ac531e7ed080").href).toBe(
-      "http://localhost/objects/8bf992c0-1547-403a-93d4-ac531e7ed080",
+  it("correctly creates link cell", () => {
+    const columnsConfig = [{
+      title: "Title",
+      data: "title",
+      type: "link",
+      linkPrefix: "/packages/",
+      identifierKey: "identifier",
+    }]
+    const output = constructColumns(columnsConfig);
+    expect(output[0]).toEqual(
+      expect.objectContaining(columnsConfig[0])
     );
+    expect(output[0].render).toStrictEqual(expect.any(Function))
+  });
+});
+
+describe("Construct URL function", () => {
+  it("correctly creates search params", () => {
+    const output = constructUrl('packages')
+    expect(output).toBe(`${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?format=datatables`)
+  });
+
+  it("correctly adds to exisitng search params", () => {
+    const output = constructUrl('packages?outcome=SUCCESS')
+    expect(output).toBe(`${process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")}/packages?outcome=SUCCESS&format=datatables`)
   });
 });

--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -10,7 +10,7 @@ export function constructUrl(path) {
     `${baseURL.replace(/\/$/, "")}/${path.replace(/^\/+/, "")}`,
   ); // Construct full URL path
   apiUrl.searchParams.append("format", "datatables"); // Adding datables format parameter to existing search params
-  return apiUrl.href
+  return apiUrl.href;
 }
 
 // Construct columns fron configuration
@@ -48,8 +48,8 @@ const DataTable = dynamic(
 );
 
 export default function Table({ apiPath, columnsConfig }) {
-  const apiUrl = constructUrl(apiPath)
-  const columns = constructColumns(columnsConfig)
+  const apiUrl = constructUrl(apiPath);
+  const columns = constructColumns(columnsConfig);
 
   return (
     <DataTable

--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
-import "datatables.net-dt/css/dataTables.dataTables.css";
 import Alert from "./Alert";
 
 // Construct fully qualified datatables URL

--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -3,6 +3,33 @@
 import dynamic from "next/dynamic";
 import "datatables.net-dt/css/dataTables.dataTables.css";
 
+// Construct fully qualified datatables URL
+export function constructUrl(path) {
+  const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL; // API base URL from .env file
+  const apiUrl = new URL(
+    `${baseURL.replace(/\/$/, "")}/${path.replace(/^\/+/, "")}`,
+  ); // Construct full URL path
+  apiUrl.searchParams.append("format", "datatables"); // Adding datables format parameter to existing search params
+  return apiUrl.href
+}
+
+// Construct columns fron configuration
+export function constructColumns(columnsConfig) {
+  return columnsConfig.map((col) => {
+    if (col.type === "link") {
+      // Add ability to specify link in column data
+      return {
+        ...col,
+        render: (data, type, row) => {
+          const identifier = row[col.identifierKey];
+          return `<a href="${col.linkPrefix}${identifier}">${data}</a>`;
+        },
+      };
+    }
+    return col;
+  });
+}
+
 // Dynamic import of DataTable component (see https://datatables.net/forums/discussion/79941/)
 const DataTable = dynamic(
   async () => {
@@ -21,25 +48,8 @@ const DataTable = dynamic(
 );
 
 export default function Table({ apiPath, columnsConfig }) {
-  const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL; // API base URL from .env file
-  const apiUrl = new URL(
-    `${baseURL.replace(/\/$/, "")}/${apiPath.replace(/^\/+/, "")}`,
-  ); // Construct full URL path
-  apiUrl.searchParams.append("format", "datatables"); // Adding datables format parameter to existing search params
-
-  const columns = columnsConfig.map((col) => {
-    if (col.type === "link") {
-      // Add ability to specify link in column data
-      return {
-        ...col,
-        render: (data, type, row) => {
-          const identifier = row[col.identifierKey];
-          return `<a href="${col.linkPrefix}${identifier}">${data}</a>`;
-        },
-      };
-    }
-    return col;
-  });
+  const apiUrl = constructUrl(apiPath)
+  const columns = constructColumns(columnsConfig)
 
   return (
     <DataTable
@@ -50,7 +60,7 @@ export default function Table({ apiPath, columnsConfig }) {
         processing: true,
         paging: true,
         serverSide: true,
-        ajax: apiUrl.href,
+        ajax: apiUrl,
         searching: true,
         ordering: true,
         lengthMenu: [10, 25, 50, 100],

--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import dynamic from "next/dynamic";
 import "datatables.net-dt/css/dataTables.dataTables.css";
+import Alert from "./Alert";
 
 // Construct fully qualified datatables URL
 export function constructUrl(path) {
@@ -50,8 +52,11 @@ const DataTable = dynamic(
 export default function Table({ apiPath, columnsConfig }) {
   const apiUrl = constructUrl(apiPath);
   const columns = constructColumns(columnsConfig);
+  const [error, setError] = useState("");
 
-  return (
+  return error ? (
+    <Alert message={error} />
+  ) : (
     <DataTable
       columns={columns}
       data={[]}
@@ -60,7 +65,20 @@ export default function Table({ apiPath, columnsConfig }) {
         processing: true,
         paging: true,
         serverSide: true,
-        ajax: apiUrl,
+        ajax: {
+          url: apiUrl,
+          error: (jqXHR, textStatus, errorThrown) => {
+            if (jqXHR.status == 0) {
+              setError(
+                `Could not fetch data from ${apiUrl}. Network error, check connection.`,
+              );
+            } else {
+              setError(
+                `Could not fetch data from ${apiUrl}. ${jqXHR.status}: ${errorThrown}`,
+              );
+            }
+          },
+        },
         searching: true,
         ordering: true,
         lengthMenu: [10, 25, 50, 100],

--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -20,7 +20,13 @@ const DataTable = dynamic(
   },
 );
 
-export default function Table({ data, columnsConfig }) {
+export default function Table({ apiPath, columnsConfig }) {
+  const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL; // API base URL from .env file
+  const apiUrl = new URL(
+    `${baseURL.replace(/\/$/, "")}/${apiPath.replace(/^\/+/, "")}`,
+  ); // Construct full URL path
+  apiUrl.searchParams.append("format", "datatables"); // Adding datables format parameter to existing search params
+
   const columns = columnsConfig.map((col) => {
     if (col.type === "link") {
       // Add ability to specify link in column data
@@ -38,11 +44,13 @@ export default function Table({ data, columnsConfig }) {
   return (
     <DataTable
       columns={columns}
-      data={data}
+      data={[]}
       className="table table-striped"
       options={{
         processing: true,
         paging: true,
+        serverSide: true,
+        ajax: apiUrl.href,
         searching: true,
         ordering: true,
         lengthMenu: [10, 25, 50, 100],

--- a/app/errors/page.js
+++ b/app/errors/page.js
@@ -1,6 +1,4 @@
 // /errors page
-import { fetchData } from "@/lib/fetchData";
-import Alert from "@/components/Alert";
 import Table from "@/components/Table";
 
 export const metadata = {
@@ -8,17 +6,21 @@ export const metadata = {
 };
 
 export default async function Errors() {
-  const data = await fetchData("/events?outcome=FAILURE");
   const columnsConfig = [
     {
       title: "Title",
       data: "package_title",
+      name: "package_identifier.title",
       type: "link",
       linkPrefix: "/packages/",
       identifierKey: "package_identifier",
     },
     { title: "Package ID", data: "package_identifier" },
-    { title: "Origin", data: "package_origin" },
+    {
+      title: "Origin",
+      data: "package_origin",
+      name: "package_identifier.origin",
+    },
     {
       title: "Service Error",
       data: "message",
@@ -31,9 +33,8 @@ export default async function Errors() {
 
   return (
     <div>
-      {data.error && <Alert message={data.error} />}
       <h1>Package Errors</h1>
-      <Table columnsConfig={columnsConfig} data={data} />
+      <Table apiPath="/events?outcome=FAILURE" columnsConfig={columnsConfig} />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,63 @@
 		bottom: 30%;
 	}
 }
+
+/*
+ * Custom local styles for datatables
+ */
+
+/* Increase cell padding to match RAC Style Library */
+table.dataTable > tbody > tr > th,
+table.dataTable > tbody > tr > td {
+  padding: 20px;
+}
+
+table.dataTable > thead > tr > th,
+table.dataTable > thead > tr > td {
+  padding: 10px 20px;
+}
+
+/* Darken hover styles */
+table.dataTable thead > tr > th.dt-orderable-asc:hover, table.dataTable thead > tr > th.dt-orderable-desc:hover,
+table.dataTable thead > tr > td.dt-orderable-asc:hover,
+table.dataTable thead > tr > td.dt-orderable-desc:hover {
+  outline: 2px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Adjust loading indicator color */
+div.dt-processing > div:last-child > div {
+  background: #192d48;
+}
+
+/* Adjust styles for search input and entries per page select */
+.dt-layout-row label {
+  font-size: 16px;
+}
+
+.dt-search input, .dt-length select {
+  width: auto;
+}
+
+div.dt-container .dt-search input {
+  appearance: none;
+  border: 1px solid #2e2e2e;
+  border-radius: 0;
+  font-size: 18px;
+  padding: 10px;
+  width: 100%;
+
+  @media screen and (min-width: 580px) {
+    width: 400px;
+  }
+}
+
+/* Pagination font styles */
+.dt-paging {
+  font-family: 'Lato', sans-serif;
+  font-size: 17px;
+}
+
+/* Make tables responsive by enabling horizontal scroll */
+.dt-layout-full {
+  overflow-x: auto;
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,3 +1,4 @@
+import "datatables.net-dt/css/dataTables.dataTables.css";
 import "./globals.css";
 import Link from "next/link";
 

--- a/app/packages/[identifier]/page.js
+++ b/app/packages/[identifier]/page.js
@@ -11,14 +11,8 @@ export const metadata = {
 
 export default async function PackageDetail({ params }) {
   const { identifier } = await params;
-
-  const [eventsData, packageData] = await Promise.all([
-    fetchData(`/packages/${identifier}/events`),
-    fetchData(`/packages/${identifier}`),
-  ]);
-
-  const error = eventsData.error || packageData.error;
-  const outcome = eventsData[0]?.outcome; // Get the most recent event outcome for the package
+  const packageData = await fetchData(`/packages/${identifier}`)
+  const error = packageData.error;
   const identifiers = packageData.identifiers || {};
 
   const columnsConfig = [
@@ -50,7 +44,7 @@ export default async function PackageDetail({ params }) {
       ) : (
         <>
           <div className="mb-50">
-            <OutcomeBadge outcome={outcome} />
+            <OutcomeBadge outcome={packageData.last_outcome} />
           </div>
           <SummaryList
             className="mb-50"

--- a/app/packages/[identifier]/page.js
+++ b/app/packages/[identifier]/page.js
@@ -63,7 +63,10 @@ export default async function PackageDetail({ params }) {
 
           <h2>Package Events</h2>
           <div className="mb-50">
-            <Table columnsConfig={columnsConfig} data={eventsData} />
+            <Table
+              apiPath={`/packages/${identifier}/events`}
+              columnsConfig={columnsConfig}
+            />
           </div>
 
           <SummaryList

--- a/app/packages/[identifier]/page.js
+++ b/app/packages/[identifier]/page.js
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default async function PackageDetail({ params }) {
   const { identifier } = await params;
-  const packageData = await fetchData(`/packages/${identifier}`)
+  const packageData = await fetchData(`/packages/${identifier}`);
   const error = packageData.error;
   const identifiers = packageData.identifiers || {};
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,10 +1,7 @@
 // Homepage of app
-import { fetchData } from "@/lib/fetchData";
-import Alert from "@/components/Alert";
 import Table from "@/components/Table";
 
 export default async function Home() {
-  const data = await fetchData("/packages");
   const columnsConfig = [
     {
       title: "Title",
@@ -20,14 +17,13 @@ export default async function Home() {
 
   return (
     <div>
-      {data.error && <Alert message={data.error} />}
       <h1>Zodiac</h1>
       <p>
         Track ingest of packages and fix errors for born digital and digitized
         content.
       </p>
       <h2>Package Status</h2>
-      <Table data={data} columnsConfig={columnsConfig} />
+      <Table apiPath="/packages/" columnsConfig={columnsConfig} />
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --fix",
+    "lint": "next lint",
     "test": "jest --coverage",
     "prepare": "husky"
   },


### PR DESCRIPTION
This uses the functionality that's now in the zodiac_backend `development` branch (and deployed) to use server-side fetching for Datatables. Noting that this removes the Alert component in a couple of instances when the fetchData command was also removed because the fetch is delegated to Datatables. Datatables will throw an alert when a request it makes fails.

I ran into some challenges developing tests for this, because it's difficult to mock the request that datatables is making under the hood. I also tried to just check the component props, but that also didn't work because of the dynamic import.

Off the top of my head, a couple of approaches:
- Remove testing of Datatables (not great since there are some significant internals that it would be good to have tests for.)
- See if there's a way we can have the Datatable do both server side and client side rendering, because the only place we really need to do server side rendering is on the home page (and maybe the errors page?) and this would allow us to test most of the internals of that component without the server side fetch.