### PR TITLE
Add Matomo Tag Manager Tracking

### DIFF
--- a/app/components/MatomoTagManager.js
+++ b/app/components/MatomoTagManager.js
@@ -1,0 +1,18 @@
+import Script from "next/script";
+
+const MatomoTagManager = () => {
+  return (
+    <Script id="matomo-tag-manager">
+      {`
+        var _mtm = window._mtm = window._mtm || [];
+        _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+        (function() {
+          var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+          g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_cDPJweu4.js'; s.parentNode.insertBefore(g,s);
+        })();
+      `}
+    </Script>
+  );
+};
+
+export default MatomoTagManager;

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import "datatables.net-dt/css/dataTables.dataTables.css";
 import "./globals.css";
 import Link from "next/link";
+import Script from "next/script";
 
 export const metadata = {
   title: "Zodiac",
@@ -11,6 +12,18 @@ export const metadata = {
 export default function Template({ children }) {
   return (
     <html lang="en">
+      <head>
+        <Script id="matomo-tag-manager">
+          {`
+            var _mtm = window._mtm = window._mtm || [];
+            _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+            (function() {
+              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+              g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_cDPJweu4.js'; s.parentNode.insertBefore(g,s);
+            })();
+          `}
+        </Script>
+      </head>
       <body>
         <div id="root">
           <Link href="#main" className="skip-link">

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,7 +1,7 @@
 import "datatables.net-dt/css/dataTables.dataTables.css";
 import "./globals.css";
 import Link from "next/link";
-import Script from "next/script";
+import MatomoTagManager from "./components/MatomoTagManager";
 
 export const metadata = {
   title: "Zodiac",
@@ -13,16 +13,7 @@ export default function Template({ children }) {
   return (
     <html lang="en">
       <head>
-        <Script id="matomo-tag-manager">
-          {`
-            var _mtm = window._mtm = window._mtm || [];
-            _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-            (function() {
-              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-              g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_cDPJweu4.js'; s.parentNode.insertBefore(g,s);
-            })();
-          `}
-        </Script>
+        <MatomoTagManager />
       </head>
       <body>
         <div id="root">


### PR DESCRIPTION
Adds script to `<head>` to enable analytics tracking. Correctly tracking pageviews with client-side routing is handled outside of this app in Matomo Tag Manager using the History Change trigger and following this guide: [https://matomo.org/faq/how-to/faq_23636/](https://matomo.org/faq/how-to/faq_23636/).

I tested it, and it seems to be working as expected.