### PR TITLE
Update aria live regions

### DIFF
--- a/app/__tests__/Alert.test.js
+++ b/app/__tests__/Alert.test.js
@@ -10,6 +10,6 @@ describe("Alert Component", () => {
     expect(screen.getByText("error_outline")).toBeInTheDocument(); // icon
     expect(screen.getByText("error_outline").parentElement).toHaveClass(
       "alert alert--orange",
-    ); // alert div
+    );
   });
 });

--- a/app/components/Alert.js
+++ b/app/components/Alert.js
@@ -1,5 +1,5 @@
 const Alert = ({ color = "orange", icon = "error_outline", message }) => (
-  <div className={`alert alert--${color}`} role="status">
+  <div className={`alert alert--${color}`}>
     <span className="alert__icon" aria-hidden="true">
       {icon}
     </span>

--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -10,11 +10,11 @@ export function constructUrl(path) {
   const apiUrl = new URL(
     `${baseURL.replace(/\/$/, "")}/${path.replace(/^\/+/, "")}`,
   ); // Construct full URL path
-  apiUrl.searchParams.append("format", "datatables"); // Adding datables format parameter to existing search params
+  apiUrl.searchParams.append("format", "datatables"); // Add datatables format parameter to existing search params
   return apiUrl.href;
 }
 
-// Construct columns fron configuration
+// Construct columns from configuration
 export function constructColumns(columnsConfig) {
   return columnsConfig.map((col) => {
     if (col.type === "link") {

--- a/app/events/[identifier]/page.js
+++ b/app/events/[identifier]/page.js
@@ -18,7 +18,9 @@ export default async function EventDetail({ params }) {
     <div>
       <h1>Event Details</h1>
 
-      <LocalStorageAlert />
+      <div role="status">
+        <LocalStorageAlert />
+      </div>
 
       {eventData.error ? (
         <>


### PR DESCRIPTION
Removes aria-live announcement for alerts that generally won't appear after page load. I think the only one that warrants a live announcement is the LocalStorageAlert on the events page.

Fix #3 