### PR TITLE
Debugs search on package errors page

### DIFF
--- a/app/errors/page.js
+++ b/app/errors/page.js
@@ -15,7 +15,11 @@ export default async function Errors() {
       linkPrefix: "/packages/",
       identifierKey: "package_identifier",
     },
-    { title: "Package ID", data: "package_identifier" },
+    {
+      title: "Package ID",
+      data: "package_identifier",
+      name: "package_identifier.identifier",
+    },
     {
       title: "Origin",
       data: "package_origin",


### PR DESCRIPTION
Explicitly target the package identifier to avoid errors when resolving relationships during search.

fixes #46